### PR TITLE
fix repeated tagged-to-i deopt

### DIFF
--- a/lib/compile_sort.js
+++ b/lib/compile_sort.js
@@ -230,9 +230,9 @@ function createQuickSort(order, dtype, insertionSort) {
     "ptr0",
     "ptr1",
     "ptr2",
-    "comp_pivot1",
-    "comp_pivot2",
-    "comp"
+    "comp_pivot1=0",
+    "comp_pivot2=0",
+    "comp=0"
   ]
   
   if(order.length > 1) {


### PR DESCRIPTION
the comp_pivot variables were occasionally being used before being initialized.
the tagged-to-i operation would bail because of NaN being introduced when they
were used.

To test this, I modified the "simple.js" example to work as follows:

``` javascript
var ndarray = require("ndarray")
var ndsort = require("../sort.js")
var unpack = require("ndarray-unpack")

var N = 100000;
var NX = 3;
var NY = 100;
var arrays = [];
//Create an array
for (var z = 0; z < N; ++z) { 
  var x = ndarray(new Float32Array(NY * NX), [NY, NX])

  for(var i=0; i<NY; ++i) {
    for(var j=0; j<NX; ++j) {
      x.set(i,j, Math.random())
    }
  }

  arrays.push(x);
}

//Sort x

for(var i = 0; i < N; ++i) {
  ndsort(arrays[i])
}
```

The remaining deopts appear to happen due to a combination of OSR and branching preventing full type collection. I roughly backported [this patch](https://groups.google.com/forum/#!topic/v8-dev/laSb2A-hz5A) to v0.10 node to diagnose this. You can apply [my patch](https://gist.github.com/chrisdickinson/d1232c5c3f15a27c95d2) to a checkout of node v0.10 branch to get that info out of `--code-comments`.

Also, merry :christmas_tree:!
